### PR TITLE
Overhaul the API and performance.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,11 @@ license = "MIT"
 
 [dependencies]
 futures = "^0.1"
+parking_lot = "^0.7"
+slab = "^0.4"
+tokio-executor = "^0.1"
+tokio-sync = "^0.1"
 tokio-timer = "^0.2"
 
 [dev-dependencies]
-tokio-executor = "^0.1"
+tokio = { version = "^0.1", features = ["reactor", "timer", "tokio-current-thread"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,27 +29,44 @@
 //! By combining a way to track the number of current users, as well as a way to fire a global
 //! timeout, we allow applications to provide soft shutdown capabilities, giving work a chance to
 //! complete, before forcefully stopping computation.
+//!
+//! `tokio-evacuate` depends on Tokio facilities, and so will not work on other futures executors.
 #[macro_use]
 extern crate futures;
+extern crate parking_lot;
+extern crate slab;
+extern crate tokio_executor;
+extern crate tokio_sync;
 extern crate tokio_timer;
 
-#[cfg(test)]
-extern crate tokio_executor;
-
-use futures::{
-    future::Fuse,
-    prelude::*,
-    sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+use futures::{future::Fuse, prelude::*};
+use parking_lot::Mutex;
+use slab::Slab;
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
-use std::time::Duration;
+use tokio_executor::{DefaultExecutor, Executor, SpawnError};
+use tokio_sync::task::AtomicTask;
 use tokio_timer::{clock::now as clock_now, Delay};
+
+#[derive(Default)]
+struct Inner {
+    count: AtomicUsize,
+    finished: AtomicBool,
+    notifier: AtomicTask,
+    waiters: Mutex<Slab<Arc<AtomicTask>>>,
+}
 
 /// Dispatcher for user count updates.
 ///
 /// [`Warden`] is cloneable.
 #[derive(Clone)]
 pub struct Warden {
-    pub(crate) notify_tx: UnboundedSender<bool>,
+    state: Arc<Inner>,
 }
 
 /// A future for safely "evacuating" a resource that is used by multiple parties.
@@ -62,58 +79,77 @@ pub struct Warden {
 /// configured value, and race between the user count dropping to zero and the timeout firing.
 ///
 /// The user count is updated by calls to [`Warden::increment`] and [`Warden::decrement`].
-pub struct Evacuate<F: Future> {
-    count: u64,
-    notify_rx: UnboundedReceiver<bool>,
+///
+/// [`Evacuate`] can be cloned, and all clones will become ready at the same time.
+pub struct Evacuate {
+    state: Arc<Inner>,
+    task: Arc<AtomicTask>,
+    waiter_id: usize,
+}
+
+pub struct Runner<F: Future> {
+    state: Arc<Inner>,
     tripwire: Fuse<F>,
     timeout_ms: u64,
     timeout: Delay,
 }
 
-impl Warden {
-    /// Increments the user count.
-    pub fn increment(&self) { let _ = self.notify_tx.unbounded_send(true); }
+impl Inner {
+    pub fn new() -> Arc<Inner> { Arc::new(Default::default()) }
 
-    /// Decrements the user count.
-    pub fn decrement(&self) { let _ = self.notify_tx.unbounded_send(false); }
-}
+    pub fn increment(&self) { self.count.fetch_add(1, Ordering::SeqCst); }
 
-impl<F: Future> Evacuate<F> {
-    /// Creates a new [`Evacuate`].
-    ///
-    /// The given `tripwire` is used, and the internal timeout is set to the value of `timeout_ms`.
-    ///
-    /// Returns both a [`Warden`] handle, used for incrementing and decrementing the user count, and
-    /// [`Evacuate`] itself.
-    pub fn new(tripwire: F, timeout_ms: u64) -> (Warden, Evacuate<F>) {
-        let (notify_tx, notify_rx) = unbounded();
+    pub fn decrement(&self) {
+        if self.count.fetch_sub(1, Ordering::SeqCst) == 1 {
+            self.notifier.notify();
+        }
+    }
 
-        let warden = Warden { notify_tx };
-        let evacuate = Evacuate {
-            count: 0,
-            notify_rx,
-            tripwire: tripwire.fuse(),
-            timeout_ms,
-            timeout: Delay::new(clock_now()),
-        };
+    pub fn register(&self, waiter: Arc<AtomicTask>) -> usize {
+        let mut waiters = self.waiters.lock();
+        waiters.insert(waiter)
+    }
 
-        (warden, evacuate)
+    pub fn unregister(&self, waiter_id: usize) {
+        let mut waiters = self.waiters.lock();
+        let _ = waiters.remove(waiter_id);
+    }
+
+    pub fn notify(&self) {
+        self.finished.store(true, Ordering::SeqCst);
+
+        let waiters = self.waiters.lock();
+        for waiter in waiters.iter() {
+            waiter.1.notify();
+        }
     }
 }
 
-impl<F: Future> Future for Evacuate<F> {
+impl Warden {
+    /// Increments the user count.
+    pub fn increment(&self) { self.state.increment(); }
+
+    /// Decrements the user count.
+    pub fn decrement(&self) { self.state.decrement(); }
+}
+
+impl<F: Future> Runner<F> {
+    pub(crate) fn new(tripwire: F, timeout_ms: u64, state: Arc<Inner>) -> Runner<F> {
+        Runner {
+            state,
+            tripwire: tripwire.fuse(),
+            timeout_ms,
+            timeout: Delay::new(clock_now()),
+        }
+    }
+}
+
+impl<F: Future> Future for Runner<F> {
     type Error = ();
     type Item = ();
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        // Drain the notifications queue to make sure we keep getting notified.
-        while let Ok(Async::Ready(Some(state))) = self.notify_rx.poll() {
-            if state {
-                self.count += 1;
-            } else {
-                self.count -= 1;
-            }
-        }
+        self.state.notifier.register();
 
         // We have to wait for our tripwire.
         if !self.tripwire.is_done() {
@@ -125,20 +161,106 @@ impl<F: Future> Future for Evacuate<F> {
 
         // We've tripped, so let's see what we're at for count.  If we're at zero, then we're done,
         // otherwise, fall through and see if we've hit our delay yet.
-        if self.count == 0 {
-            // We've tripped and we're at count 0, so we're done.
+        if self.state.count.load(Ordering::SeqCst) == 0 {
+            // We've tripped and we're at count 0, so we're done.  Notify waiters.
+            self.state.notify();
             return Ok(Async::Ready(()));
         }
 
         // Our count isn't at zero, but let's see if we've timed out yet.
-        self.timeout.poll().map_err(|_| ())
+        try_ready!(self.timeout.poll().map_err(|_| ()));
+
+        // We timed out, so mark ourselves finished and notify.
+        self.state.notify();
+
+        Ok(Async::Ready(()))
+    }
+}
+
+impl Evacuate {
+    /// Creates a new [`Evacuate`].
+    ///
+    /// The given `tripwire` is used, and the internal timeout is set to the value of `timeout_ms`.
+    ///
+    /// Returns a [`Warden`] handle, used for incrementing and decrementing the user count, an
+    /// [`Evacuate`] future, which callers can select/poll against directly, and a [`Runner`]
+    /// future which must be spawned manually to drive the inner behavior of [`Evacuate`].
+    ///
+    /// If you're using Tokio, you can call [`default_executor`] to spawn the runner on the default
+    /// executor.
+    pub fn new<F>(tripwire: F, timeout_ms: u64) -> (Warden, Evacuate, Runner<F>)
+    where
+        F: Future + Send + 'static,
+    {
+        let state = Inner::new();
+        let warden = Warden { state: state.clone() };
+
+        let task = Arc::new(AtomicTask::new());
+        let waiter_id = state.register(task.clone());
+
+        let evacuate = Evacuate {
+            state: state.clone(),
+            task,
+            waiter_id,
+        };
+
+        let runner = Runner::new(tripwire, timeout_ms, state);
+
+        (warden, evacuate, runner)
+    }
+
+    /// Creates a new [`Evacuate`], based on the default executor.
+    ///
+    /// The given `tripwire` is used, and the internal timeout is set to the value of `timeout_ms`.
+    ///
+    /// Returns a [`Warden`] handle, used for incrementing and decrementing the user count, and an
+    /// [`Evacuate`] future, which callers can select/poll against directly.
+    ///
+    /// This functions spawns a background task on the default executor which drives the state
+    /// machine powering [`Evacuate`].  This function must be called from within a running task.
+    pub fn default_executor<F>(tripwire: F, timeout_ms: u64) -> Result<(Warden, Evacuate), SpawnError>
+    where
+        F: Future + Send + 'static,
+    {
+        let (warden, evacuate, runner) = Self::new(tripwire, timeout_ms);
+
+        DefaultExecutor::current()
+            .spawn(Box::new(runner))
+            .map(move |_| (warden, evacuate))
+    }
+}
+
+impl Drop for Evacuate {
+    fn drop(&mut self) { self.state.unregister(self.waiter_id); }
+}
+
+impl Clone for Evacuate {
+    fn clone(&self) -> Self {
+        let state = self.state.clone();
+        let task = Arc::new(AtomicTask::new());
+        let waiter_id = state.register(task.clone());
+
+        Evacuate { state, task, waiter_id }
+    }
+}
+
+impl Future for Evacuate {
+    type Error = ();
+    type Item = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.task.register();
+
+        if !self.state.finished.load(Ordering::SeqCst) {
+            Ok(Async::NotReady)
+        } else {
+            Ok(Async::Ready(()))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    extern crate tokio_executor;
-
     #[macro_use]
     mod support;
     use self::support::*;
@@ -154,7 +276,7 @@ mod tests {
     fn test_evacuate_stops_at_tripwire() {
         mocked(|_, _| {
             let tripwire = empty::<(), ()>();
-            let (_warden, mut evacuate) = Evacuate::new(tripwire, 10000);
+            let (_warden, mut evacuate, _runner) = Evacuate::new(tripwire, 10000);
             assert_not_ready!(evacuate);
         });
     }
@@ -163,7 +285,9 @@ mod tests {
     fn test_evacuate_falls_through_on_tripwire() {
         mocked(|_, _| {
             let tripwire = ok::<(), ()>(());
-            let (_warden, mut evacuate) = Evacuate::new(tripwire, 10000);
+            let (_warden, mut evacuate, mut runner) = Evacuate::new(tripwire, 10000);
+            assert_not_ready!(evacuate);
+            assert_ready!(runner);
             assert_ready!(evacuate);
         });
     }
@@ -172,8 +296,11 @@ mod tests {
     fn test_evacuate_stops_after_tripping_with_clients() {
         mocked(|_, _| {
             let tripwire = ok::<(), ()>(());
-            let (warden, mut evacuate) = Evacuate::new(tripwire, 10000);
+            let (warden, mut evacuate, mut runner) = Evacuate::new(tripwire, 10000);
+            assert_not_ready!(evacuate);
             warden.increment();
+
+            assert_not_ready!(runner);
             assert_not_ready!(evacuate);
         });
     }
@@ -182,13 +309,16 @@ mod tests {
     fn test_evacuate_completes_after_client_count_ping_pong() {
         mocked(|_, _| {
             let tripwire = ok::<(), ()>(());
-            let (warden, mut evacuate) = Evacuate::new(tripwire, 10000);
+            let (warden, mut evacuate, mut runner) = Evacuate::new(tripwire, 10000);
             warden.increment();
+            assert_not_ready!(runner);
             assert_not_ready!(evacuate);
             warden.increment();
+            assert_not_ready!(runner);
             assert_not_ready!(evacuate);
             warden.decrement();
             warden.decrement();
+            assert_ready!(runner);
             assert_ready!(evacuate);
         });
     }
@@ -197,16 +327,19 @@ mod tests {
     fn test_evacuate_delay_before_clients_hit_zero() {
         mocked(|timer, _| {
             let tripwire = ok::<(), ()>(());
-            let (warden, mut evacuate) = Evacuate::new(tripwire, 10000);
+            let (warden, mut evacuate, mut runner) = Evacuate::new(tripwire, 10000);
             warden.increment();
+            assert_not_ready!(runner);
             assert_not_ready!(evacuate);
             warden.increment();
+            assert_not_ready!(runner);
             assert_not_ready!(evacuate);
             warden.decrement();
+            assert_not_ready!(runner);
             assert_not_ready!(evacuate);
             advance(timer, ms(10001));
+            assert_ready!(runner);
             assert_ready!(evacuate);
         });
     }
-
 }


### PR DESCRIPTION
Instead of requiring users to clone their evacuation future by using `Shared`, `Evacuate` itself now supports being cloned by introducing some background machinery that manages the count/timeout logic as well as notifying tasks polling an evacuate future.

As this requires a separate task to drive this behavior, `Evacuate::new` now returns a third value in the tuple, a future that must be spawned on an available executor.  There's also a new function, `Evacuate::default_executor` which will spawn the runner for the caller on the default Tokio executor. This means it can only be used when already instead a running task.